### PR TITLE
Additional Phrases/Words and Minor Fixes

### DIFF
--- a/tagmod-translations.json
+++ b/tagmod-translations.json
@@ -244,6 +244,14 @@
 			{
 				"value": "Budget",
 				"translation": "Budget"
+			},
+			{
+				"value": "Select Staff",
+				"translation": "Sélectionner le personnel"
+			},
+			{
+				"value": "Choose Engine",
+				"translation": "Choisir le moteur"
 			}
 		]
 	},
@@ -260,6 +268,10 @@
 			{
 				"value": "Game Contracts",
 				"translation": "Contratti di Lavoro"
+			},
+			{
+				"value": "Topic and Genre",
+				"translation": "Thema e Genere"
 			},
 			{
 				"value": "Topic",
@@ -476,6 +488,14 @@
 			{
 				"value": "Budget",
 				"translation": "Bilancio"
+			},
+			{
+				"value": "Select Staff",
+				"translation": "Selezionare il Personale"
+			},
+			{
+				"value": "Choose Engine",
+				"translation": "Scegli il Motore"
 			}
 		]
 	}

--- a/tagmod-translations.json
+++ b/tagmod-translations.json
@@ -1,4 +1,4 @@
-{
+﻿{
 	"de": {
 		"values":[
 			{
@@ -150,7 +150,19 @@
 				"translation": "Phase"
 			},
 			{
-				"value": "Time allocation",
+				"value": "Stage 1",
+				"translation": "Phase 1"
+			},
+			{
+				"value": "Stage 2",
+				"translation": "Phase 2"
+			},
+			{
+				"value": "Stage 3",
+				"translation": "Phase 3"
+			},
+			{
+				"value": "Time Allocation",
 				"translation": "Répartition du temps"
 			},
 			{
@@ -224,6 +236,14 @@
 			{
 				"value": "Insights",
 				"translation": "Insights"
+			},
+			{
+				"value": "Engine Development",
+				"translation": "Développement du moteur"
+			},
+			{
+				"value": "Budget",
+				"translation": "Budget"
 			}
 		]
 	},
@@ -366,7 +386,19 @@
 				"translation": "Fase"
 			},
 			{
-				"value": "Time allocation",
+				"value": "Stage 1",
+				"translation": "Fase 1"
+			},
+			{
+				"value": "Stage 2",
+				"translation": "Fase 2"
+			},
+			{
+				"value": "Stage 3",
+				"translation": "Fase 3"
+			},
+			{
+				"value": "Time Allocation",
 				"translation": "Allocazione Tempo"
 			},
 			{
@@ -436,6 +468,14 @@
 			{
 				"value": "Insights",
 				"translation": "Approfondimenti"
+			},
+			{
+				"value": "Engine Development",
+				"translation": "Sviluppo del Motore"
+			},
+			{
+				"value": "Budget",
+				"translation": "Bilancio"
 			}
 		]
 	}


### PR DESCRIPTION
Added translations for "Budget", "Engine Development", "Stage 1", "Stage 2", "Stage 3", "Select Staff" and "Choose Engine". Fixed "Time Allocation" which had been incorrectly listed as "Time allocation". Added "Topic and Genre" to Italian translation. 
